### PR TITLE
Add Python tokeniser for genes codon samplesequence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ vignettes/*.pdf
 
 # Shiny token, see https://shiny.rstudio.com/articles/shinyapps.html
 rsconnect/
+
+# JetBrains IDEs
+.idea/

--- a/python/tic/__init__.py
+++ b/python/tic/__init__.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+

--- a/python/tic/create/__init__.py
+++ b/python/tic/create/__init__.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+

--- a/python/tic/create/tokenisers/__init__.py
+++ b/python/tic/create/tokenisers/__init__.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+

--- a/python/tic/create/tokenisers/discrete/__init__.py
+++ b/python/tic/create/tokenisers/discrete/__init__.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+

--- a/python/tic/create/tokenisers/discrete/genes_codon_samplesequence.py
+++ b/python/tic/create/tokenisers/discrete/genes_codon_samplesequence.py
@@ -11,8 +11,8 @@ from tic.utils import readlines
 
 def tokenise(data_source_path: str) -> Iterator[List[str]]:
     for line in readlines(data_source_path):
-        line_tokens = []
         line = line.strip().lower()
+        line_tokens = []
         for idx in range(math.floor(len(line) / 3)):
             for char in range(3):
                 start = (idx * 3) + char
@@ -28,6 +28,10 @@ if __name__ == '__main__':
 
     input_path = os.path.join(os.getcwd(), '/Users/thimic/Developer/TIC/ordered.txt')
     output_path = os.path.join(os.getcwd(), 'tokenised.csv')
+
+    # Remove existing output files before writing
+    if os.path.isfile(output_path):
+        os.remove(output_path)
 
     from _datetime import datetime
     t0 = datetime.now()

--- a/python/tic/create/tokenisers/discrete/genes_codon_samplesequence.py
+++ b/python/tic/create/tokenisers/discrete/genes_codon_samplesequence.py
@@ -4,15 +4,12 @@
 import os
 
 import math
-from typing import Any, Optional, List
+from typing import Iterator, List
 
 from tic.utils import readlines
 
 
-def tokenise(data_source_path: str) -> Any:
-
-    tokenised = []
-
+def tokenise(data_source_path: str) -> Iterator[List[str]]:
     for line in readlines(data_source_path):
         line_tokens = []
         line = line.strip().lower()
@@ -24,19 +21,20 @@ def tokenise(data_source_path: str) -> Any:
                 if len(codon) == 3 and 'n' not in codon and '-' not in codon:
                     token = f'pos{idx + 1}#+{char + 1}#{codon}'
                     line_tokens.append(token)
-        tokenised.append(line_tokens)
-    return tokenised
+        yield line_tokens
 
 
 if __name__ == '__main__':
-    from _datetime import datetime
-    t0 = datetime.now()
+
+    input_path = os.path.join(os.getcwd(), '/Users/thimic/Developer/TIC/ordered.txt')
     output_path = os.path.join(os.getcwd(), 'tokenised.csv')
 
-    tokenised = tokenise('/Users/thimic/Developer/TIC/ordered.txt')
-    lines = [', '.join(line_tokens) for line_tokens in tokenised]
+    from _datetime import datetime
+    t0 = datetime.now()
 
-    with open(output_path, 'w') as stream:
-        stream.writelines(lines)
+    with open(output_path, 'a') as stream:
+        for line_tokens in tokenise(input_path):
+            line = ', '.join(line_tokens)
+            stream.write(line)
 
     print(f'Finished in {datetime.now() - t0}')

--- a/python/tic/create/tokenisers/discrete/genes_codon_samplesequence.py
+++ b/python/tic/create/tokenisers/discrete/genes_codon_samplesequence.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+
+import math
+from typing import Any, Optional, List
+
+from tic.utils import readlines
+
+
+def tokenise(data_source_path: str) -> Any:
+
+    tokenised = []
+
+    for line in readlines(data_source_path):
+        line_tokens = []
+        line = line.strip().lower()
+        for idx in range(math.floor(len(line) / 3)):
+            for char in range(3):
+                start = (idx * 3) + char
+                end = (idx * 3) + 3 + char
+                codon = line[start:end]
+                if len(codon) == 3 and 'n' not in codon and '-' not in codon:
+                    token = f'pos{idx + 1}#+{char + 1}#{codon}'
+                    line_tokens.append(token)
+        tokenised.append(line_tokens)
+    return tokenised
+
+
+if __name__ == '__main__':
+    from _datetime import datetime
+    t0 = datetime.now()
+    output_path = os.path.join(os.getcwd(), 'tokenised.csv')
+
+    tokenised = tokenise('/Users/thimic/Developer/TIC/ordered.txt')
+    lines = [', '.join(line_tokens) for line_tokens in tokenised]
+
+    with open(output_path, 'w') as stream:
+        stream.writelines(lines)
+
+    print(f'Finished in {datetime.now() - t0}')

--- a/python/tic/utils.py
+++ b/python/tic/utils.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+
+from typing import Iterator
+
+
+def readlines(file_path: str) -> Iterator[str]:
+    file_path = os.path.join(os.getcwd(), file_path)
+    with open(file_path, 'r') as stream:
+        while True:
+            line = stream.readline()
+            if not line:
+                break
+            yield line

--- a/src/createTIC/tokenisers/discrete/genes-CODON-samplesequence/tokeniser.R
+++ b/src/createTIC/tokenisers/discrete/genes-CODON-samplesequence/tokeniser.R
@@ -1,9 +1,11 @@
 # MAIN FUNCTION -----------------------------------------------------------
 
-tokenise <- function(dataSource,no_cores){
+tokenise <- function(dataSource){
   # read source data
-  sourceData <- readr::read_csv(paste0(getwd(),"/data/",dataSource), col_names = F)
+  sourceData <- readr::read_csv(paste0(getwd(),"/",dataSource), col_names = F)
   sourceData$X1 <- tolower(sourceData$X1)
+
+  print(floor(nchar(sourceData$X1[1])/3)-1)
   
   tokenised <- list()
   
@@ -11,8 +13,8 @@ tokenise <- function(dataSource,no_cores){
     cdn <- c()
     for(j in 0:(floor(nchar(sourceData$X1[i])/3)-1)){
       for(k in 0:2){
-        if(nchar(substr(c(sourceData$X1)[i],((j*3)+1+k),((j*3)+3+k))) == 3 & !grepl("n",substr(c(sourceData$X1)[i],((j*3)+1+k),((j*3)+3+k))) & !grepl("-",substr(c(sourceData$X1)[i],((j*3)+1+k),((j*3)+3+k))))
-        cdn <- c(cdn,paste0("pos",j+1,"#+",k+1,"#",substr(c(sourceData$X1)[i],((j*3)+1+k),((j*3)+3+k))))
+        if(nchar(substr(sourceData$X1[i],((j*3)+1+k),((j*3)+3+k))) == 3 & !grepl("n",substr(sourceData$X1[i],((j*3)+1+k),((j*3)+3+k))) & !grepl("-",substr(sourceData$X1[i],((j*3)+1+k),((j*3)+3+k))))
+        cdn <- c(cdn,paste0("pos",j+1,"#+",k+1,"#",substr(sourceData$X1[i],((j*3)+1+k),((j*3)+3+k))))
       }
     }
     
@@ -26,7 +28,10 @@ tokenise <- function(dataSource,no_cores){
   return(tokenised)
 }
 
-
+setwd("/Users/thimic/Developer/TIC")
+system.time(
+tokens <- tokenise("ordered_short.txt")
+)
 # SUPPORT FUNCTIONS -------------------------------------------------------
 
 


### PR DESCRIPTION
Python tokeniser only for Genes Codon Sample Sequence. Could do with some cleaning up. 

Tokenises the provided `ordered.txt` in about 1m 10s.